### PR TITLE
Fix delete duplicate parameter sets

### DIFF
--- a/lib/membrane_h264_plugin/h26x_parser.ex
+++ b/lib/membrane_h264_plugin/h26x_parser.ex
@@ -335,7 +335,7 @@ defmodule Membrane.H26x.Parser do
   @spec delete_duplicate_parameter_sets(AUSplitter.access_unit(), state()) ::
           AUSplitter.access_unit()
   defp delete_duplicate_parameter_sets(au, state) do
-    if state.module.keyframe?(au), do: Enum.uniq(au), else: au
+    if state.module.keyframe?(au), do: Enum.uniq_by(au, & &1.payload), else: au
   end
 
   @spec maybe_add_parameter_sets(AUSplitter.access_unit(), state()) ::


### PR DESCRIPTION
We delete the duplicate parameter sets by using `Enum.uniq(au)`, however the parameter sets NAL units may contain different timestamps. 
Fixed by comparing the `payload` instead of the whole `struct`. 