### PR TITLE
Sets the timestamps from the last processed buf to the NAL units flused out in handle_end_of_stream. Bump to v0.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package can be installed by adding `membrane_h26x_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_h26x_plugin, "~> 0.10.3"}
+    {:membrane_h26x_plugin, "~> 0.10.4"}
   ]
 end
 ```

--- a/lib/membrane_h264_plugin/h26x_parser.ex
+++ b/lib/membrane_h264_plugin/h26x_parser.ex
@@ -212,7 +212,14 @@ defmodule Membrane.H26x.Parser do
   @spec handle_end_of_stream(callback_context(), state()) :: callback_return()
   def handle_end_of_stream(ctx, state) do
     {nalus_payloads, nalu_splitter} = NALuSplitter.split(<<>>, true, state.nalu_splitter)
-    {nalus, nalu_parser} = state.nalu_parser_mod.parse_nalus(nalus_payloads, state.nalu_parser)
+
+    {nalus, nalu_parser} =
+      state.nalu_parser_mod.parse_nalus(
+        nalus_payloads,
+        state.previous_buffer_timestamps,
+        state.nalu_parser
+      )
+
     {access_units, au_splitter} = state.au_splitter_mod.split(nalus, true, state.au_splitter)
 
     state = %{

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H26x.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.10.3"
+  @version "0.10.4"
   @github_url "https://github.com/membraneframework/membrane_h26x_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* sets the timestamps of the NAL units flushed out in the `handle_end_of_stream` to the timestamps of the last processed buffer
* bump the version to v0.10.4